### PR TITLE
Use dynamic allocation for the FIL structure. *TESTED*

### DIFF
--- a/components/fatfs/src/vfs_fat.c
+++ b/components/fatfs/src/vfs_fat.c
@@ -185,7 +185,7 @@ static int get_next_fd(vfs_fat_ctx_t* fat_ctx)
             if (fat_ctx->files[i] == NULL) {
                 return -1; // out of memory
             }
-            return i;
+            return (int) i;
         }
     }
     return -1;

--- a/components/fatfs/src/vfs_fat.c
+++ b/components/fatfs/src/vfs_fat.c
@@ -185,6 +185,7 @@ static int get_next_fd(vfs_fat_ctx_t* fat_ctx)
             if (fat_ctx->files[i] == NULL) {
                 return -1; // out of memory
             }
+            return i;
         }
     }
     return -1;


### PR DESCRIPTION
With this patch we need 4 bytes per max_files entry. The 4 KB structure
is only allocated when we open a file.